### PR TITLE
Add demos tab and MPS demo link. Change path of source files to relative

### DIFF
--- a/src/download/demos.html
+++ b/src/download/demos.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Open 3D Engine - Windows 10 Installer Download</title>
+        <title>Open 3D Engine - Demos</title>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width,initial-scale=1">
-        <meta name="title" content="Open 3D Engine - Windows 10 Installer Download">
-        <meta name="description" content="Open 3D Engine - Windows 10 Installer Download">
+        <meta name="title" content="Open 3D Engine - Demos">
+        <meta name="description" content="Open 3D Engine - Demos">
 
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -20,23 +20,22 @@
                 <div class="logo-subtitle">BINARIES</div>
             </div>
             <div class="navbar-os">
-                <span class="os-button current">WINDOWS</span>
+                <a href="windows.html" class="os-button">WINDOWS</a>
                 <a href="linux.html" class="os-button">LINUX</a>
-                <a href="demos.html" class="os-button">DEMOS</a>
+                <span class="os-button current">DEMOS</span>
             </div>
         </div>
         <div class="content">
             <div class="container">
-                <h1>Install Open 3D Engine for Windows</h1>
-                <h3>Thank you for downloading the O3DE Windows Installer</h3>
+                <h1>Play the O3DE Multiplayer Sample Demo</h1>
+                <h3>This demo was created with O3DE and does not require the engine to play</h3>
                 <p>By downloading these files, you agree to the <a href="../license.html" target="_blank">End User License Agreement</a>.</p>
                 <p>
-                    <a href="https://o3debinaries.org/main/Latest/Windows/o3de_installer_2305_0.exe" class="btn">Download v23.05.0 Release</a>
+                    <a href="https://o3debinaries.org/mps/o3demps-2305.zip" class="btn">Download Multiplayer Sample Demo</a>
                 </p>
 				<br/>
 				<p class="small-note">
-					Try out features and fixes currently in development by downloading the <a href="https://o3debinaries.org/development/Latest/Windows/o3de_installer.exe">Nightly Development Build here</a>. 
-					Note: These nightly builds are created automatically from the latest source code revisions in the O3DE development branch. These builds contain untested features and possible bugs.
+					The source and assets for this demo can be found on <a href="https://github.com/o3de/o3de-multiplayersample-assets">Github</a>.
 				</p>
             </div>
         </div>

--- a/src/download/download.css
+++ b/src/download/download.css
@@ -159,7 +159,7 @@ a
     display: block;
     margin-top: 72px;
     width: 100%;
-    background-image: url('./images/background.png');
+    background-image: url('../images/background.png');
     background-size: cover;
     background-position: 50% 50%;
     padding: 2% 0;

--- a/src/download/linux.html
+++ b/src/download/linux.html
@@ -16,19 +16,20 @@
     <body>
         <div class="navbar">
             <div class="navbar-logo">
-                <img src="/images/O3DE-Logo-REV-Mono.svg" class="logo"/>
+                <img src="../images/O3DE-Logo-REV-Mono.svg" class="logo"/>
                 <div class="logo-subtitle">BINARIES</div>
             </div>
             <div class="navbar-os">
                 <a href="windows.html" class="os-button">WINDOWS</a>
                 <span class="os-button current">LINUX</span>
+                <a href="demos.html" class="os-button">DEMOS</a>
             </div>
         </div>
         <div class="content">
             <div class="container">
                 <h1>Install Open 3D Engine for Linux</h1>
                 <h3>Thank you for downloading the O3DE Debian Package</h3>
-                <p>By downloading these files, you agree to the <a href="/license.html" target="_blank">End User License Agreement</a>.</p>
+                <p>By downloading these files, you agree to the <a href="../license.html" target="_blank">End User License Agreement</a>.</p>
                 <p>
                     <a href="https://o3debinaries.org/main/Latest/Linux/o3de_2305_0.deb" class="btn">Download v23.05.0 Release</a><span class="additional-download-url">Additional Downloads: <a href="https://o3debinaries.org/main/Latest/Linux/o3de_2305_0.deb.sha256">SHA256</a> <a href="https://o3debinaries.org/main/Latest/Linux/o3de-releases.gpg">GPG</a></span>
                 </p>
@@ -42,7 +43,7 @@
         <div class="footer">
             <div class="container">
                 <div class="footer-logo">
-                    <img src="/images/O3DE-Logo-REV-Mono.svg" class="logo"/>
+                    <img src="../images/O3DE-Logo-REV-Mono.svg" class="logo"/>
                     <div class="logo-subtitle">BINARIES</div>
                 </div>
                 <p>Copyright &copy; 2022 Open 3D Engine Binaries | Documentation Distributed under <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0.</a></p>


### PR DESCRIPTION
- Adds a new "Demos" tab for the MPS demo. 
- The paths of all source assets changed to relative to allow for local preview

Testing done:
Preview can be found here: https://d2o572vhva5jdo.cloudfront.net/download/demos.html