### PR TITLE
Update for the 23.10.0 release

### DIFF
--- a/src/download/linux.html
+++ b/src/download/linux.html
@@ -31,7 +31,7 @@
                 <h3>Thank you for downloading the O3DE Debian Package</h3>
                 <p>By downloading these files, you agree to the <a href="../license.html" target="_blank">End User License Agreement</a>.</p>
                 <p>
-                    <a href="https://o3debinaries.org/main/Latest/Linux/o3de_2305_1.deb" class="btn">Download v23.05.1 Release</a><span class="additional-download-url">Additional Downloads: <a href="https://o3debinaries.org/main/Latest/Linux/o3de_2305_1.deb.sha256">SHA256</a> <a href="https://o3debinaries.org/main/Latest/Linux/o3de-releases.gpg">GPG</a></span>
+                    <a href="https://o3debinaries.org/main/Latest/Linux/o3de_2310_0.deb" class="btn">Download v23.10.0 Release</a><span class="additional-download-url">Additional Downloads: <a href="https://o3debinaries.org/main/Latest/Linux/o3de_2310_0.deb.sha256">SHA256</a> <a href="https://o3debinaries.org/main/Latest/Linux/o3de-releases.gpg">GPG</a></span>
                 </p>
                 
                 <a href="https://snapcraft.io/o3de">
@@ -39,7 +39,7 @@
                 </a>
 				<br/>
 				<p class="small-note">
-					Try out features and fixes currently in development by downloading the Nightly Development Build here: <a href="https://o3debinaries.org/development/Latest/Linux/O3DE_latest.deb">Debian Package</a> (<a href="https://o3debinaries.org/development/Latest/Linux/O3DE_latest.deb.sha256">SHA256</a> <a href="https://o3debinaries.org/main/Latest/Linux/o3de-releases.gpg">GPG</a>)
+					Try out features and fixes currently in development by downloading the Nightly Development Build here: <a href="https://o3debinaries.org/development/Latest/Linux/o3de_latest.deb">Debian Package</a> (<a href="https://o3debinaries.org/development/Latest/Linux/o3de_latest.deb.sha256">SHA256</a> <a href="https://o3debinaries.org/main/Latest/Linux/o3de-releases.gpg">GPG</a>)
                     or <a href="https://o3debinaries.org/2.1.0/Linux/o3de_2.1.0_amd64.snap">Snap Package</a> (<a href="https://o3debinaries.org/2.1.0/Linux/o3de_2.1.0_amd64.snap.sha384">SHA384</a> <a href="https://o3debinaries.org/main/Latest/Linux/o3de-releases.gpg">GPG</a>). 
 					<br>Note: These nightly builds are created automatically from the latest source code revisions in the O3DE development branch, which may contain untested features and possible bugs.</br>
 				</p>

--- a/src/download/windows.html
+++ b/src/download/windows.html
@@ -31,7 +31,7 @@
                 <h3>Thank you for downloading the O3DE Windows Installer</h3>
                 <p>By downloading these files, you agree to the <a href="../license.html" target="_blank">End User License Agreement</a>.</p>
                 <p>
-                    <a href="https://o3debinaries.org/main/Latest/Windows/o3de_installer_2305_1.exe" class="btn">Download v23.05.1 Release</a>
+                    <a href="https://o3debinaries.org/main/Latest/Windows/o3de_installer_2310_0.exe" class="btn">Download v23.10.0 Release</a>
                 </p>
 				<br/>
 				<p class="small-note">


### PR DESCRIPTION
Updates the page for the 2310 release with new links.

Tested locally. This will be pushed to a preview here:

Windows: https://d2o572vhva5jdo.cloudfront.net/download/windows.html
Linux: https://d2o572vhva5jdo.cloudfront.net/download/linux.html