### PR TITLE
Fixes the release notes link for 2510.0

### DIFF
--- a/src/download/windows.html
+++ b/src/download/windows.html
@@ -55,7 +55,7 @@
                 <p>
                     <a href="https://o3debinaries.org/main/Latest/Windows/o3de_installer_2510_0-offline.zip" class="btn">Download v25.10.0 Release - Offline</a>
                 </p>
-                <p><a href="https://github.com/o3de/sig-release/blob/main/releases/25.10.1/25.10.1.md" target="_blank">Release notes for v25.10.1</a></p>
+                <p><a href="https://github.com/o3de/sig-release/blob/main/releases/25.10.0/25.10.0.md" target="_blank">Release notes for v25.10.0</a></p>
                 <br>
                 <p>
                     <a href="https://o3debinaries.org/main/Latest/Windows/o3de_installer_2505_1.exe" class="btn">Download v25.05.1 Release</a>


### PR DESCRIPTION
Previews here:

Windows: https://d2o572vhva5jdo.cloudfront.net/download/windows.html
Linux: https://d2o572vhva5jdo.cloudfront.net/download/linux.html